### PR TITLE
Correct commenting in .gitignore for service output & ignore .idea

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,14 +34,25 @@ build/Release
 node_modules
 
 ### Service Output
-.nyc-output # GDP of NYC? (@lel)
-_book # Gitbook Output
-assets/app.js # Barebones App
-assets/service.js # Service Files; Minified service file that, if included, runs
-assets/fabric.min.js # Minified fabric.js bundle
+# GDP of NYC? (@lel)
+.nyc-output
+# Gitbook Output
+_book
+# Barebones App
+assets/app.js
+# Service Files; Minified service file that, if included, runs
+assets/service.js
+# Minified fabric.js bundle
+assets/fabric.min.js
 
 # Hide bitcoin node blocks
 stores
 
 # Nix
 result*
+
+# IntelliJ
+.idea
+
+_book
+


### PR DESCRIPTION
I noticed that `_book` was not being ignored. So I moved the mid-line hash to the line above for that case and for others I saw.  

Should `assets/service.js` be removed from the repo?

Also added the IntelliJ project file to `.gitignore`