### PR TITLE
Fix broken link to RPG Marketplace

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -25,7 +25,7 @@ We're borne of a swarm of storytellers, eager to tell a tale.  [Join `#lobby:rol
 
 ## Further Reading
 - [`DEVELOPERS.md`](DEVELOPERS.md)
-- [The RPG Marketplace](https://www.roleplaygateway.com/orders)
+- [The RPG Marketplace](https://rpgmarket.com/)
 - [RPG's Rules](https://www.roleplaygateway.com/rules)
 
 [chat-beta]: https://grove.chat/#/room/#beta:fabric.pub


### PR DESCRIPTION
Replaced the outdated RPG Marketplace URL (https://www.roleplaygateway.com/orders) with the current working link (https://rpgmarket.com/) in the "Further Reading" section of CONTRIBUTING.md. This ensures users are directed to the correct resource.